### PR TITLE
fixed retain cycle that caused memory leaks 

### DIFF
--- a/EmarsysPredictSDK/EMRecommendationItem.m
+++ b/EmarsysPredictSDK/EMRecommendationItem.m
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EMRecommendationItem ()
 
 /// Recommendation result.
-@property(readonly) EMRecommendationResult *result;
+@property(weak, readonly) EMRecommendationResult *result;
 @end
 
 @implementation EMRecommendationItem {


### PR DESCRIPTION
fixed retain cycle that caused memory leaks between EMRecommendationResult and EMREcommendationItem
<img width="1264" alt="3" src="https://user-images.githubusercontent.com/17595547/33321190-7f97b6ae-d44d-11e7-8514-dbbf2b665b84.png">
<img width="1003" alt="2" src="https://user-images.githubusercontent.com/17595547/33321191-7fb27598-d44d-11e7-80c4-9fa4d7328997.png">
