### PR TITLE
pass the correct error variable to error handler for invalid status codes

### DIFF
--- a/EmarsysPredictSDK/EMSession.m
+++ b/EmarsysPredictSDK/EMSession.m
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
           err = [NSError errorWithDomain:EMErrorDomain
                                     code:EMErrorBadHTTPStatus
                                 userInfo:d];
-          errorHandler(error);
+          errorHandler(err);
           return;
       }
       // Find cdv


### PR DESCRIPTION
The old code uses the url loading error instead of the created error for invalid status codes